### PR TITLE
 Support Ledger 1.3.7 with MC 1.21.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-	id 'fabric-loom' version '1.6.+'
+	id 'fabric-loom' version '1.9-SNAPSHOT'
 	id 'maven-publish'
-	id 'org.jetbrains.kotlin.jvm' version "1.8.22"
+	id 'org.jetbrains.kotlin.jvm' version "2.0.0"
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -28,9 +28,11 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Yes this has to be capitalised
-	modImplementation "com.github.quiltservertools:Ledger:1.3.0+local"
+	// To publish Ledger on mavenLocal, see this page:
+	// https://www.quiltservertools.net/Ledger/latest/api/extension_development/
+	modImplementation "com.github.quiltservertools:Ledger:1.3.7+local"
 
-	modImplementation "net.fabricmc:fabric-language-kotlin:1.9.4+kotlin.1.8.21"
+	modImplementation "net.fabricmc:fabric-language-kotlin:1.11.0+kotlin.2.0.0"
 
 	implementation(include("com.zaxxer:HikariCP:5.0.1"))
 
@@ -58,7 +60,15 @@ processResources {
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
 
-	it.options.release = 17
+	it.options.release = 21
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+	kotlinOptions.jvmTarget = "21"
+}
+
+kotlin {
+	jvmToolchain(21)
 }
 
 java {


### PR DESCRIPTION
## Background

I was having issues with integrating Ledger 1.3.7 to this extension on an existing MariaDB. So I took it upon myself to fix the issue.

## Changes

- Update dependencies: fabric-loom, kotlin jvm
- Update Java version: 17 -> 21
- Tested on Minecraft 1.21.4 with `fabric-api-0.115.0+1.21.4`, 
- Tested on Ledger 1.3.7 connected to MariaDB `11.5.2`

## Action Items for Maintainers

- [ ] Review PR
- [ ] Update [Modrinth Page](https://modrinth.com/mod/ledger-databases) & GitHub description, to include Maria & Postgres
- [ ] Increment mod version (?)

Thank you, have a great day.