### PR TITLE
Make the mod buildable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-	id 'fabric-loom' version '1.6.+'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 	id 'maven-publish'
-	id 'org.jetbrains.kotlin.jvm' version "1.8.22"
+	id 'org.jetbrains.kotlin.jvm' version "2.1.0"
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -58,7 +58,7 @@ processResources {
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
 
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,14 @@ group = project.maven_group
 
 repositories {
 	mavenLocal()
+	mavenCentral()
 	maven {
 		url = "https://maven.nucleoid.xyz"
 	}
 	maven {
 		url = "https://oss.sonatype.org/content/repositories/snapshots"
 	}
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -32,7 +34,12 @@ dependencies {
 
 	modImplementation "net.fabricmc:fabric-language-kotlin:1.9.4+kotlin.1.8.21"
 
+	implementation(include("com.uchuhimo:konf-core:1.1.2"))
+
 	implementation(include("com.zaxxer:HikariCP:5.0.1"))
+
+	// SQLite
+	implementation(include('org.xerial:sqlite-jdbc:3.30.1'))
 
 	// H2
 	implementation(include("com.h2database:h2:2.2.224"))

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Yes this has to be capitalised
-	modImplementation "com.github.quiltservertools:Ledger:1.3.0+local"
+	modImplementation "com.github.quiltservertools:Ledger:1.3.10+local"
 
 	modImplementation "net.fabricmc:fabric-language-kotlin:1.9.4+kotlin.1.8.21"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I wanted to test the MariaDB changes and as they are not published on Modrinth, I cloned the mod and tried building in local for myself.

When I did that, I saw that the Gradle version was outdated (8.1.1 while the version of `fabric-loom` requested Gradle 8.9 or above)\
I updated to use same `fabric-loom` and Gradle version as latest version of Ledger.

After that, I had an other issue with the Kotlin JVM, I update to the same version as Ledger too.

In the same time, I changed the target version of the Ledger to 3.10 to be accurate with the main branch of it.

I was able to execute Gradle, but now when I tried to build, it told me that it was missing `konf` and `sqlite-jdbc`. The fact they were missing as dependencies was very strange as they are used but, yes, they aren't declared anywhere, so I added both to the `build.gradle` too.